### PR TITLE
Remove Newtonsoft.Json external dependency

### DIFF
--- a/Log4Slack/Log4Slack.csproj
+++ b/Log4Slack/Log4Slack.csproj
@@ -34,13 +34,10 @@
     <Reference Include="log4net">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Log4Slack/SlackClient.cs
+++ b/Log4Slack/SlackClient.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
 using System.Text;
-using Newtonsoft.Json;
 
 namespace Log4Slack {
     /// <summary>
@@ -82,7 +84,7 @@ namespace Log4Slack {
         /// Posts a payload to Slack.
         /// </summary>
         private void PostPayloadAsync(Payload payload) {
-            var data = JsonConvert.SerializeObject(payload);
+            var data = JsonSerializeObject(payload);
             PostPayloadAsync(data);
         }
 
@@ -160,22 +162,32 @@ namespace Log4Slack {
                 OnWebPostError(request, e);
             }
         }
+
+        private static string JsonSerializeObject(object obj) {
+            var serializer = new DataContractJsonSerializer(obj.GetType());
+            using (var stream = new MemoryStream())
+            {
+                serializer.WriteObject(stream, obj);
+                return Encoding.UTF8.GetString(stream.ToArray());
+            }
+        }
     }
 
 
     /// <summary>
     /// The payload to send to Stack, which will be serialized to JSON before POSTing.
     /// </summary>
+    [DataContract]
     public class Payload {
-        [JsonProperty("channel")]
+        [DataMember(Name = "channel")]
         public string Channel { get; set; }
-        [JsonProperty("username")]
+        [DataMember(Name = "username")]
         public string Username { get; set; }
-        [JsonProperty("icon_url")]
+        [DataMember(Name = "icon_url")]
         public string IconUrl { get; set; }
-        [JsonProperty("text")]
+        [DataMember(Name = "text")]
         public string Text { get; set; }
-        [JsonProperty("attachments")]
+        [DataMember(Name = "attachments")]
         public List<Attachment> Attachments { get; set; }
     }
 
@@ -183,37 +195,38 @@ namespace Log4Slack {
     /// It is possible to create more richly-formatted messages using Attachments.
     /// https://api.slack.com/docs/attachments
     /// </summary>
+    [DataContract]
     public class Attachment {
         /// <summary>
         /// Required text summary of the attachment that is shown by clients that understand attachments but choose not to show them.
         /// </summary>
-        [JsonProperty("fallback")]
+        [DataMember(Name = "fallback")]
         public string Fallback { get; set; }
 
         /// <summary>
         /// Optional text that should appear above the formatted data.
         /// </summary>
-        [JsonProperty("pretext")]
+        [DataMember(Name = "pretext")]
         public string PreText { get; set; }
 
         /// <summary>
         /// Optional text that should appear within the attachment.
         /// </summary>
-        [JsonProperty("text")]
+        [DataMember(Name = "text")]
         public string Text { get; set; }
 
         /// <summary>
         /// Can either be one of 'good', 'warning', 'danger', or any hex color code.
         /// </summary>
-        [JsonProperty("color")]
+        [DataMember(Name = "color")]
         public string Color { get; set; }
 
         /// <summary>
         /// Fields are displayed in a table on the message.
         /// </summary>
-        [JsonProperty("fields")]
+        [DataMember(Name = "fields")]
         public List<Field> Fields { get; set; }
-        [JsonProperty("mrkdwn_in")]
+        [DataMember(Name = "mrkdwn_in")]
         public List<string> MarkdownIn { get; private set; }
 
         public Attachment(string fallback) {
@@ -225,21 +238,22 @@ namespace Log4Slack {
     /// <summary>
     /// Fields are displayed in a table on the message.
     /// </summary>
+    [DataContract]
     public class Field {
         /// <summary>
         /// The title may not contain markup and will be escaped for you; required.
         /// </summary>
-        [JsonProperty("title")]
+        [DataMember(Name = "title")]
         public string Title { get; set; }
         /// <summary>
         /// Text value of the field. May contain standard message markup and must be escaped as normal; may be multi-line.
         /// </summary>
-        [JsonProperty("value")]
+        [DataMember(Name = "value")]
         public string Value { get; set; }
         /// <summary>
         /// Optional flag indicating whether the <paramref name="Value"/> is short enough to be displayed side-by-side with other values.
         /// </summary>
-        [JsonProperty("short")]
+        [DataMember(Name = "short")]
         public bool Short { get; set; }
 
         public Field(string title) {
@@ -247,5 +261,3 @@ namespace Log4Slack {
         }
     }
 }
-
-

--- a/Log4Slack/packages.config
+++ b/Log4Slack/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.3" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
... and use `System.Runtime.Serialization` instead for JSON serialization.

Based on these stats
- `Newtonsoft.Json.dll` is 500KB 
- `log4net.dll` is 300KB 
- `Log4Slack` compiles to 12KB

It looked like good idea to completely remove the external dependency. For instance I'm currently using `ServiceStack.Text` for JSON/XML serialization so Newtonsoft's library is of no use to my project.