### PR TITLE
Allow environ vars in appender config values

### DIFF
--- a/Log4Slack/SlackAppender.cs
+++ b/Log4Slack/SlackAppender.cs
@@ -2,10 +2,11 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using log4net.Appender;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Log4Slack {
-    public class SlackAppender : AppenderSkeleton {
+    public class SlackAppender : log4net.Appender.AppenderSkeleton {
         private readonly Process _currentProcess = Process.GetCurrentProcess();
 
         /// <summary>
@@ -62,7 +63,8 @@ namespace Log4Slack {
 
             if (AddAttachment) {
                 // Set fallback string
-                var theAttachment = new Attachment(string.Format("[{0}] {1} in {2} on {3}", loggingEvent.Level.DisplayName, loggingEvent.LoggerName, _currentProcess.ProcessName, Environment.MachineName));
+                var theAttachment = new Attachment(string.Format("[{0}] {1} in {2} on {3}", loggingEvent.Level.DisplayName, 
+                    loggingEvent.LoggerName, _currentProcess.ProcessName, Environment.MachineName));
 
                 // Determine attachment color
                 switch (loggingEvent.Level.DisplayName.ToLowerInvariant()) {
@@ -77,38 +79,31 @@ namespace Log4Slack {
 
                 // Add attachment fields
                 theAttachment.Fields = new List<Field> {
-                    new Field("Process") {Value = _currentProcess.ProcessName, Short = true},
-                    new Field("Machine") {Value = Environment.MachineName, Short = true}
+                    new Field("Process", Value: _currentProcess.ProcessName, Short: true),
+                    new Field("Machine", Value: Environment.MachineName, Short: true)
                 };
                 if (!UsernameAppendLoggerName)
-                    theAttachment.Fields.Insert(0, new Field("Logger") { Value = loggingEvent.LoggerName, Short = true });
+                    theAttachment.Fields.Insert(0, new Field("Logger", Value: loggingEvent.LoggerName, Short: true));
 
                 // Add exception fields if exception occurred
                 var exception = loggingEvent.ExceptionObject;
                 if (exception != null) {
-                    if (AddExceptionTraceField && !string.IsNullOrWhiteSpace(exception.StackTrace))
-                        theAttachment.Fields.Insert(0, new Field("Exception Trace") { Value = "```" + exception.StackTrace + "```" });
-                    theAttachment.Fields.Insert(0, new Field("Exception Type") { Value = exception.GetType().Name, Short = true });
-                    theAttachment.Fields.Insert(0, new Field("Exception Message") { Value = exception.Message, Short = true });
+                    theAttachment.Fields.Insert(0, new Field("Exception Type", Value: exception.GetType().Name, Short: true));
+                    if (AddExceptionTraceField && !string.IsNullOrWhiteSpace(exception.StackTrace)) {
+                        var parts = exception.StackTrace.SplitOn(1990).ToArray();
+                        for(int idx = parts.Length - 1; idx >= 0; idx--) {
+                            var name = "Exception Trace" + (idx > 0 ? string.Format(" {0}", idx + 1) : null);
+                            theAttachment.Fields.Insert(0, new Field(name, Value: "```" + parts[idx].Replace("```", "'''") + "```"));
+                        }
+                    }
+                    theAttachment.Fields.Insert(0, new Field("Exception Message", Value: exception.Message));
                 }
 
                 attachments.Add(theAttachment);
             }
 
-            String formattedMessage = loggingEvent.RenderedMessage;
-            if (Layout != null)
-            {
-                using (StringWriter writer = new StringWriter())
-                {
-                    Layout.Format(writer, loggingEvent);
-                    formattedMessage = writer.ToString();
-                }
-            }
-
-            var username = Username.Expand();
-            if (UsernameAppendLoggerName)
-                username += " - " + loggingEvent.LoggerName;
-
+            var formattedMessage = (Layout != null ? Layout.FormatString(loggingEvent) : loggingEvent.RenderedMessage);
+            var username = Username.Expand() + (UsernameAppendLoggerName ? " - " + loggingEvent.LoggerName : null);
             slackClient.PostMessageAsync(formattedMessage, username, Channel.Expand(), IconUrl.Expand(), IconEmoji.Expand(), attachments);
         }
     }
@@ -119,5 +114,20 @@ namespace Log4Slack {
         {
             return text != null ? Environment.ExpandEnvironmentVariables(text) : null;
         }
+
+        public static IEnumerable<string> SplitOn(this string text, int numChars)
+        {
+            var SplitOnPattern = new Regex(string.Format(@"(?<line>.{{1,{0}}})([\r\n]|$)", numChars), RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            return SplitOnPattern.Matches(text).OfType<Match>().Select(m => m.Groups["line"].Value);
+        }
+
+        public static string FormatString(this log4net.Layout.ILayout layout, log4net.Core.LoggingEvent loggingEvent)
+        {
+            using (var writer = new StringWriter()) {
+                layout.Format(writer, loggingEvent);
+                return writer.ToString();
+            }
+        }
+
     }
 }

--- a/Log4Slack/SlackAppender.cs
+++ b/Log4Slack/SlackAppender.cs
@@ -57,7 +57,7 @@ namespace Log4Slack {
 
         protected override void Append(log4net.Core.LoggingEvent loggingEvent) {
             // Initialze the Slack client
-            var slackClient = new SlackClient(WebhookUrl);
+            var slackClient = new SlackClient(WebhookUrl.Expand());
             var attachments = new List<Attachment>();
 
             if (AddAttachment) {
@@ -81,7 +81,7 @@ namespace Log4Slack {
                     new Field("Machine") {Value = Environment.MachineName, Short = true}
                 };
                 if (!UsernameAppendLoggerName)
-                    theAttachment.Fields.Insert(0, new Field("Logger") {Value = loggingEvent.LoggerName, Short = true});
+                    theAttachment.Fields.Insert(0, new Field("Logger") { Value = loggingEvent.LoggerName, Short = true });
 
                 // Add exception fields if exception occurred
                 var exception = loggingEvent.ExceptionObject;
@@ -98,18 +98,26 @@ namespace Log4Slack {
             String formattedMessage = loggingEvent.RenderedMessage;
             if (Layout != null)
             {
-                using(StringWriter writer = new StringWriter())
+                using (StringWriter writer = new StringWriter())
                 {
                     Layout.Format(writer, loggingEvent);
                     formattedMessage = writer.ToString();
                 }
             }
-            
-            var username = Username;
+
+            var username = Username.Expand();
             if (UsernameAppendLoggerName)
                 username += " - " + loggingEvent.LoggerName;
 
-            slackClient.PostMessageAsync(formattedMessage, username, Channel, IconUrl, IconEmoji, attachments);
+            slackClient.PostMessageAsync(formattedMessage, username, Channel.Expand(), IconUrl.Expand(), IconEmoji.Expand(), attachments);
+        }
+    }
+
+    internal static class Extensions
+    {
+        public static string Expand(this string text)
+        {
+            return text != null ? Environment.ExpandEnvironmentVariables(text) : null;
         }
     }
 }

--- a/Log4Slack/SlackClient.cs
+++ b/Log4Slack/SlackClient.cs
@@ -235,6 +235,7 @@ namespace Log4Slack {
         /// </summary>
         [DataMember(Name = "fields")]
         public List<Field> Fields { get; set; }
+
         [DataMember(Name = "mrkdwn_in")]
         public List<string> MarkdownIn { get; private set; }
 
@@ -265,8 +266,10 @@ namespace Log4Slack {
         [DataMember(Name = "short")]
         public bool Short { get; set; }
 
-        public Field(string title) {
-            Title = title;
+        public Field(string Title, string Value = null, bool Short = false) {
+            this.Title = Title;
+            this.Value = Value;
+            this.Short = Short;
         }
     }
 }


### PR DESCRIPTION
This PR allows using `<Channel value="%COMPUTERNAME%" />` and similar environment based values in `SlackAppender` config.

We are using a common log4net config files for the IIS farm with `<log4net configSource="log4net.config" />` in site's `web.config` where `log4net.config` is a symbolic link to a file on a remote share so customizing channel in our case can be easily done based on a machine environment variable.