### PR TITLE
Custom colors and @mentions

### DIFF
--- a/Log4Slack/Log4Slack.csproj
+++ b/Log4Slack/Log4Slack.csproj
@@ -36,6 +36,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />

--- a/Log4Slack/SlackClient.cs
+++ b/Log4Slack/SlackClient.cs
@@ -53,8 +53,8 @@ namespace Log4Slack {
         /// <param name="iconUrl"></param>
         /// <param name="iconEmoji"></param>
         /// <param name="attachments">Optional collection of attachments.</param>
-        public void PostMessageAsync(string text, string username = null, string channel = null, string iconUrl = null, string iconEmoji = null, List<Attachment> attachments = null) {
-            var payload = BuildPayload(text, username, channel, iconUrl, iconEmoji, attachments);
+        public void PostMessageAsync(string text, string username = null, string channel = null, string iconUrl = null, string iconEmoji = null, List<Attachment> attachments = null, bool linknames = false) {
+            var payload = BuildPayload(text, username, channel, iconUrl, iconEmoji, attachments, linknames);
             PostPayloadAsync(payload);
         }
 
@@ -69,7 +69,7 @@ namespace Log4Slack {
         /// <param name="iconEmoji"></param>
         /// <param name="attachments"></param>
         /// <returns></returns>
-        private Payload BuildPayload(string text, string username, string channel, string iconUrl, string iconEmoji, List<Attachment> attachments = null) {
+        private Payload BuildPayload(string text, string username, string channel, string iconUrl, string iconEmoji, List<Attachment> attachments = null, bool linknames = false) {
             username = string.IsNullOrEmpty(username) ? _username : username;
             channel = string.IsNullOrEmpty(channel) ? _channel : channel;
             iconUrl = string.IsNullOrEmpty(iconUrl) ? _iconUrl : iconUrl;
@@ -81,7 +81,8 @@ namespace Log4Slack {
                 IconUrl = iconUrl,
                 IconEmoji = iconEmoji,
                 Text = text,
-                Attachments = attachments
+                Attachments = attachments,
+                LinkNames = Convert.ToInt32(linknames)
             };
 
             return payload;
@@ -198,6 +199,8 @@ namespace Log4Slack {
         public string Text { get; set; }
         [DataMember(Name = "attachments")]
         public List<Attachment> Attachments { get; set; }
+        [DataMember(Name = "link_names")]
+        public int LinkNames { get; set; }
     }
 
     /// <summary>

--- a/Log4SlackTesting/App.config
+++ b/Log4SlackTesting/App.config
@@ -35,9 +35,14 @@
       <AddAttachment value="true" />
       <AddExceptionTraceField value="true" />
       <UsernameAppendLoggerName value="true"/>
+      <LinkNames value="true" />
       <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="[TEST] %-5level %logger - %message" />
       </layout>
+      <mapping>
+        <level value="INFO" />
+        <backColor value="SkyBlue" />
+      </mapping>
     </appender>
   </log4net>
 </configuration>


### PR DESCRIPTION
- Can set the 'link_names' config property to tell slack to automatically link @mentions
- Allow for custom colors on the attachment